### PR TITLE
Date returns incorrectly for certain end of month dates.

### DIFF
--- a/src/core/parsing_translator.js
+++ b/src/core/parsing_translator.js
@@ -247,7 +247,7 @@
 				today = finishUtils.getToday.call(this);
 			}
 			
-			expression = !!(this.days && this.days !== null || this.orient || this.operator);
+			expression = !!(this.days !== null || this.orient || this.operator);
 			orient = ((this.orient === "past" || this.operator === "subtract") ? -1 : 1);
 
 			if (this.month && this.unit === "week") {


### PR DESCRIPTION
We were using the previous version of this code written by Geoffrey McGill and recently updated it but have found a few different issues. The first issue seems to be influenced by today's date but I only started looking at it yesterday so without waiting longer, it's hard to tell. 

Running this on 8/28/2014:
Date.parse( '9/30/2014' ) returns Mon Sep 28 2014 00:00:00 GMT-0500 (CDT)
On 8/29/2014 (today):
Date.parse( '9/30/2014' ) returns Mon Sep 29 2014 00:00:00 GMT-0500 (CDT)
I imagine that tomorrow, by virtue of it being 8/30, it'll return the correct date! ;) The only other date I have found that also returns something incorrect seemingly based on today's date is is 11/31/2014 (which is not a valid date as there are only 30 days in Nov.)

The other issue has to do with parsing dates that are a valid month but not valid for that particular month is returning a date into the future offset by the number of days that are wrong. Examples:
Date.parse( '2/30/2014' ) returns Sun Mar 02 2014 00:00:00 GMT-0600 (CST) - there are 28 days in Feb
Date.parse( '4/31/2014' ) returns Thu May 01 2014 00:00:00 GMT-0500 (CDT) - there are 30 days in Apr

...and so on. The behavior exhibited by the previous version we were using (written by Geoffrey McGill) was that those requests would return the last valid date of the month you requested which seems like preferred behavior: 
Date.parse( '2/30/2014' ) returns Fri Feb 28 2014 00:00:00 GMT-0600 (CST)

Both of these issues appear to be resolved by reverting a change made in the Translator's finish() function that was causing a variable named "expression" to evaluate incorrectly...honestly, I think this area could use a refactor to improve code readability as I cannot seem to decipher what this variable is meant to represent! 

Anyway, my git pull contains the fix. Please review and perhaps you can shed some light on this code as well?
