### PR TITLE
Fix exception thrown when using 'next' in parse string.

### DIFF
--- a/src/core/parsing_translator.js
+++ b/src/core/parsing_translator.js
@@ -71,7 +71,7 @@
 				return $D.today();
 			}
 		},
-		setDaysFromWeekday: function (today){
+		setDaysFromWeekday: function (today, orient) {
 			var gap;
 			this.unit = "day";
 			gap = ($D.getDayNumberFromName(this.weekday) - today.getDay());
@@ -276,7 +276,7 @@
 			}
 
 			if (expression && this.weekday && this.unit !== "month" && this.unit !== "week") {
-				finishUtils.setDaysFromWeekday.call(this, today);
+				finishUtils.setDaysFromWeekday.call(this, today, orient);
 			}
 
 			if (this.month && this.unit === "day" && this.operator) {


### PR DESCRIPTION
When calling Date.parse on a string such as "next monday", the parser calls setDaysFromWeekday. In this function, the local variable 'orient' is used but is never defined.
