### PR TITLE
Gracefully handle Date.parse receiving a number

### DIFF
--- a/src/core/parser.js
+++ b/src/core/parser.js
@@ -133,6 +133,9 @@
 		if (!s) {
 			return null;
 		}
+		if (typeof s === 'number') {
+			return $D._parse(s);
+		}
 		if (s instanceof Date) {
 			return s.clone();
 		}


### PR DESCRIPTION
I'm using a Vis.js Timeline component, which [internally calls `Date.parse` with a number](https://github.com/almende/vis/blob/master/lib/util.js#L395) when doing some type coersion.

Calling the native parse function with a number should either return another number, or `NaN` (although this isn't covered by the spec, IE/FF/Chrome all behave as such). However, because datejs's parser doesn't check for a number input, it falls through to attempting to normalise it as a string, which fails when hitting `parseUtils.removeOrds`.

Naturally, removing datejs and thus reverting to the native `Date.parse` method fixes this issue, but this is not an option for me as datejs's functionality is used throughout my application.

Please review this pull request, as I'm unsure whether handling numbers is something you want this method to do.