### PR TITLE
Fix for ReferenceError: output is not defined

### DIFF
--- a/src/core/core-prototypes.js
+++ b/src/core/core-prototypes.js
@@ -753,7 +753,7 @@
 		};
 	};
 	$P.toString = function (format, ignoreStandards) {
-
+                 var output;
 		// Standard Date and Time Format Strings. Formats pulled from CultureInfo file and
 		// may vary by culture.
 		if (!ignoreStandards && format && format.length === 1) {


### PR DESCRIPTION
Fix for
 Uncaught ReferenceError: output is not defined
    at $P.toString (core-prototypes.js:760:1)